### PR TITLE
Fix getUserStream function

### DIFF
--- a/AppDotNet.php
+++ b/AppDotNet.php
@@ -287,8 +287,8 @@ class AppDotNet {
 	// the Users they follow.
 	function getUserStream($user_id='me') {
 		//return $this->httpGet($this->_baseUrl.'posts/stream/global');
-		return $this->httpGet($this->_baseUrl.'users/'.$user_id.'/stream');
-
+		//return $this->httpGet($this->_baseUrl.'users/'.$user_id.'/stream');
+		return $this->httpGet($this->_baseUrl.'posts/stream');
 	}
 
 	// Returns a specific User object.


### PR DESCRIPTION
The previous fix to getUserStream function was kicking an error. And according to the api-specs it should have a url of GET https://alpha-api.app.net/stream/0/posts/stream which is what I put into the fix.
This fix works for me and it doesn't kick out an error, so unless I'm missing something, this should fix the getUserStream function
