### PR TITLE
@ravisorg & @ryantharp's proper response envelope methods, temporary inc...

### DIFF
--- a/AppDotNet.php
+++ b/AppDotNet.php
@@ -824,6 +824,10 @@ class AppDotNet {
 	 * @return true;
 	 */
 	public function closeStream() {
+		if (!$this->_lastStreamActivity) {
+			// never opened
+			return;
+		}
 		if (!$this->_multiStream) {
 			throw new AppDotNetException('You must open a stream before calling closeStream()');
 		}


### PR DESCRIPTION
...ludeResponseEnvelope support

new functions getResponseMaxID(), getResponseMinID(),
getResponseMore(), and includeResponseEnvelope(). Provides a smooth
migration path to new default returned response format. (Sorry, a
little messy my editor eats ending whitespace)
