### PR TITLE
Throw exception if response variable does not exist

### DIFF
--- a/AppDotNet.php
+++ b/AppDotNet.php
@@ -473,8 +473,13 @@ class AppDotNet {
 		}
 
 		// else non response migration response, just return it
-		else {
+		// else non response migration response, just return it
+		else if (isset($response)) {
 			return $response;
+		}
+
+		else {
+			throw new AppDotNetException("No response");
 		}
 	}
 


### PR DESCRIPTION
Sometimes the `$response` variable does not exist, because`$this->_last_response` is not truthy.
